### PR TITLE
Configure and create helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
+require 'navigation_helper.rb'
+
 module ApplicationHelper
+  include NavigationHelper
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,9 @@
+module NavigationHelper
+  def collapsible_links_partial_path
+    if user_signed_in?
+      'layouts/navigation/collapsible_elements/signed_in_links'
+    else
+      'layouts/navigation/collapsible_elements/non_signed_in_links'
+    end
+  end
+end

--- a/app/views/layouts/navigation/_collapsible_elements.html.erb
+++ b/app/views/layouts/navigation/_collapsible_elements.html.erb
@@ -1,29 +1,6 @@
 <!-- Collect the nav links, forms, and other content for toggling -->
 <div class="collapse navbar-collapse navbar-right" id="navbar-collapsible-content">
   <ul class="nav navbar-nav ">
-    <% if user_signed_in? %>
-    <li class="dropdown pc-menu">
-      <a id="user-settings" class="dropdown-toggle" data-toggle="dropdown" href="#">
-        <span id="user-name"><%= current_user.name %></span>
-        <span class="caret"></span>
-      </a>
-
-      <ul class="dropdown-menu" role="menu">
-        <li><%= link_to 'Edit Profile', edit_user_registration_path %></li>
-        <li><%= link_to 'Log out', destroy_user_session_path, method: :delete %></li>
-      </ul>
-    </li>
-
-    <li class="mobile-menu">
-      <%= link_to 'Edit Profile', edit_user_registration_path %>
-    </li>
-    <li class="mobile-menu">
-      <%= link_to 'Log out', destroy_user_session_path, method: :delete %>
-    </li>
-
-    <% else # user not signed it %>
-    <li><%= link_to 'Login', login_path %></li>
-    <li><%= link_to 'Signup', signup_path %></li>
-    <% end # if user is signed it %>
+    <%= render collapsible_links_partial_path %>
   </ul>
 </div><!-- navbar-collapse -->

--- a/app/views/layouts/navigation/collapsible_elements/_non_signed_in_links.html.erb
+++ b/app/views/layouts/navigation/collapsible_elements/_non_signed_in_links.html.erb
@@ -1,0 +1,2 @@
+<li><%= link_to 'Login', login_path %></li>
+<li><%= link_to 'Signup', signup_path %></li>

--- a/app/views/layouts/navigation/collapsible_elements/_signed_in_links.html.erb
+++ b/app/views/layouts/navigation/collapsible_elements/_signed_in_links.html.erb
@@ -1,0 +1,16 @@
+<li class="dropdown pc-menu">
+  <a id="user-settings" class="dropdown-toggle" data-toggle="dropdown" href="#">
+    <span id="user-name"><%= current_user.name %></span>
+    <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu" role="menu">
+    <li><%= link_to 'Edit Profile', edit_user_registration_path %></li>
+    <li><%= link_to 'Log out', destroy_user_session_path, method: :delete %></li>
+  </ul>
+</li>
+<li class="mobile-menu">
+  <%= link_to 'Edit Profile', edit_user_registration_path %>
+</li>
+<li class="mobile-menu">
+  <%= link_to 'Log out', destroy_user_session_path, method: :delete %>
+</li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module Bonanza
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # Overrides default helper behaviour so helper methods are not available in all views.
+    # ie: helpers are available for corresponding controller’s views only
+    config.action_controller.include_all_helpers = false
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
- Change `include_all_helpers` config to false. This is so helpers are not global, rather helpers are available to corresponding controllers only.
- Split the `_collapsible_elements.html.erb` file's content into partials and extract logic from the file into partials: This is so we are not using logic in the views.
- Extract logic from the views and put them into a helper, which will enable esier testing and management of the app